### PR TITLE
Removed flutter as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [1.1.0] 9/22/22
 * Did cleanup after Python script additions. Minor formatting.
+* Removed flutter as a dependency allowing the library to be used in dart only projects.
 
 ## [1.0.5] 9/22/22
 * Added python code generation scripts

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,7 +7,7 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
-include: package:flutter_lints/flutter.yaml
+include: package:lints/recommended.yaml
 
 analyzer:
   strong-mode:

--- a/lib/src/uuid_allocation.dart
+++ b/lib/src/uuid_allocation.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:meta/meta.dart';
 
 /// UUID Allocation data container. This structure is pulled from the PDF found
 /// (here)[https://btprodspecificationrefs.blob.core.windows.net/assigned-values/16-bit%20UUID%20Numbers%20Document.pdf]

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: bluetooth_identifiers
-description: Codification of Bluetooth specificiers for manufacturer & service data.
+description: Codification of Bluetooth specifiers for manufacturer & service data.
 version: 1.0.5
 repository: https://github.com/LEMUSADR000/bluetooth_identifiers
 homepage: https://github.com/LEMUSADR000/bluetooth_identifiers
@@ -7,13 +7,10 @@ issue_tracker: https://github.com/LEMUSADR000/bluetooth_identifiers/issues
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.5.0"
 
 dependencies:
-  flutter:
-    sdk: flutter
+  meta: '>=1.3.0 <1.9.0'
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
-  flutter_lints: ^2.0.0
+  lints: ^1.0.1
+  test: ^1.21.5


### PR DESCRIPTION
This library only uses the `meta` package via flutter. Importing this package separately and removing the dependency on flutter, adds the ability to use this library in a non flutter project. For example a dart-only CLI application.

Something for consideration is how to handle set the minimum and maximum dependency for the `meta` package.
You may want to update it to `>=1.3.0 <2.0.0` so that the library doesn't need constant updates. Or even `>=1.3.0` and assume that the `@immutable` annotation doesn't get removed in a future update.